### PR TITLE
typo in dutch translation

### DIFF
--- a/src/main/res/values-nl/strings.xml
+++ b/src/main/res/values-nl/strings.xml
@@ -25,7 +25,7 @@
     <string name="drawer_item_favorites">Favorieten</string>
     <string name="drawer_item_photos">Foto\'s</string>
     <string name="drawer_item_on_device">Op het apparaat</string>
-    <string name="drawer_item_recently_added">Recent toegevoged</string>
+    <string name="drawer_item_recently_added">Recent toegevoegd</string>
     <string name="drawer_item_recently_modified">Recent gewijzigd</string>
     <string name="drawer_item_shared">Gedeeld</string>
     <string name="drawer_item_videos">Video\'s</string>


### PR DESCRIPTION
There is an typo in the dutch translation.
toegevoged should be toegevoegd